### PR TITLE
feat(helm): support Traefik ingress via configurable controller

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -217,6 +217,25 @@ Get effective microprofileConfig for public (merged shared + instance-specific)
 {{- end -}}
 
 {{/*
+Ingress controller type (nginx | traefik).
+Drives path syntax and which built-in controller annotations are emitted.
+*/}}
+{{- define "mgnl.ingress.controller" -}}
+{{- .Values.magnolia.ingress.controller | default "nginx" -}}
+{{- end -}}
+
+{{/*
+Resolve the effective ingressClassName for an ingress object.
+Usage: include "mgnl.ingressClassName" (dict "instance" $instanceClassName "ctx" $)
+Returns the instance override if set, otherwise the shared className, otherwise empty.
+*/}}
+{{- define "mgnl.ingressClassName" -}}
+{{- $instance := .instance | default "" -}}
+{{- $shared := .ctx.Values.magnolia.ingress.className | default "" -}}
+{{- $instance | default $shared -}}
+{{- end -}}
+
+{{/*
 Get effective ingress annotations for author (merged shared + instance-specific)
 */}}
 {{- define "mgnl.author.ingress.annotations" -}}

--- a/helm/templates/magnolia-author-assets.ing.yaml
+++ b/helm/templates/magnolia-author-assets.ing.yaml
@@ -11,12 +11,25 @@ metadata:
   name: {{ include "mgnl.author.name" . }}-assets
   labels:
     {{- include "mgnl.labels" . | nindent 4 }}
-  {{- $mergedAnnotations := include "mgnl.author.assetIngress.annotations" . | fromYaml }}
+  {{- $controller := include "mgnl.ingress.controller" . }}
+  {{- $userAnnotations := include "mgnl.author.assetIngress.annotations" . | fromYaml }}
+  {{- $builtin := dict }}
+  {{- if eq $controller "nginx" }}
+  {{- $builtin = `nginx.ingress.kubernetes.io/rewrite-target: /dam/$1
+nginx.ingress.kubernetes.io/configuration-snippet: |
+  more_set_headers "X-Robots-Tag: noindex";
+` | fromYaml }}
+  {{- end }}
+  {{- $mergedAnnotations := merge $userAnnotations $builtin }}
   {{- if $mergedAnnotations }}
   annotations:
     {{- toYaml $mergedAnnotations | nindent 4 }}
   {{- end }}
 spec:
+  {{- $className := include "mgnl.ingressClassName" (dict "instance" .Values.magnoliaAuthor.assetIngress.className "ctx" $) }}
+  {{- if $className }}
+  ingressClassName: {{ $className }}
+  {{- end }}
   tls:
     - hosts:
         - {{ .Values.magnoliaAuthor.assetIngress.hostname }}
@@ -25,8 +38,10 @@ spec:
     - host: {{ .Values.magnoliaAuthor.assetIngress.hostname }}
       http:
         paths:
-          - path: /(.*)
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+          - path: {{ if eq $controller "traefik" }}/{{ else }}/(.*){{ end }}
+            {{- if eq $controller "traefik" }}
+            pathType: Prefix
+            {{- else if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: ImplementationSpecific
             {{- end }}
             backend:

--- a/helm/templates/magnolia-author-preview-redirect.ing.yaml
+++ b/helm/templates/magnolia-author-preview-redirect.ing.yaml
@@ -6,16 +6,27 @@ metadata:
   labels:
     {{- include "mgnl.labels" . | nindent 4 }}
     app.kubernetes.io/component: magnolia-author-preview-redirect
+  {{- $controller := include "mgnl.ingress.controller" . }}
+  {{- $extra := .Values.magnoliaAuthor.previewRedirect.ingress.annotations | default dict }}
+  {{- $builtin := dict }}
+  {{- if eq $controller "nginx" }}
+  {{- $builtin = dict "nginx.ingress.kubernetes.io/use-regex" "true" }}
+  {{- end }}
+  {{- $mergedAnnotations := merge $extra $builtin }}
+  {{- if or $mergedAnnotations (and .Values.ipWhitelist (eq $controller "nginx")) }}
   annotations:
-    nginx.ingress.kubernetes.io/use-regex: "true"
-    {{- $extra := .Values.magnoliaAuthor.previewRedirect.ingress.annotations | default dict }}
-    {{- if $extra }}
-    {{- toYaml $extra | nindent 4 }}
+    {{- with $mergedAnnotations }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- if .Values.ipWhitelist }}
+    {{- if and .Values.ipWhitelist (eq $controller "nginx") }}
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ join "," .Values.ipWhitelist }}"
     {{- end }}
+  {{- end }}
 spec:
+  {{- $className := include "mgnl.ingressClassName" (dict "instance" .Values.magnoliaAuthor.previewRedirect.ingress.className "ctx" $) }}
+  {{- if $className }}
+  ingressClassName: {{ $className }}
+  {{- end }}
   tls:
     - hosts:
         - {{ .Values.magnoliaAuthor.ingress.hostname }}
@@ -25,8 +36,8 @@ spec:
       http:
         paths:
           {{- range .Values.magnoliaAuthor.previewRedirect.routes }}
-          - path: /{{ .pathPrefix }}(?:/.+)?\.html
-            pathType: ImplementationSpecific
+          - path: {{ if .path }}{{ .path }}{{ else if eq $controller "traefik" }}/{{ .pathPrefix }}{{ else }}/{{ .pathPrefix }}(?:/.+)?\.html{{ end }}
+            pathType: {{ .pathType | default (ternary "Prefix" "ImplementationSpecific" (eq $controller "traefik")) }}
             backend:
               service:
                 name: {{ include "mgnl.author.previewRedirect.name" $ }}

--- a/helm/templates/magnolia-author.ing.yaml
+++ b/helm/templates/magnolia-author.ing.yaml
@@ -15,15 +15,22 @@ metadata:
       {{- toYaml $mergedLabels | nindent 4 }}
     {{- end }}
     {{- include "mgnl.labels" . | nindent 4 }}
+  {{- $controller := include "mgnl.ingress.controller" . }}
   {{- $mergedAnnotations := include "mgnl.author.ingress.annotations" . | fromYaml }}
-  {{- if $mergedAnnotations }}
+  {{- if or $mergedAnnotations (and .Values.ipWhitelist (eq $controller "nginx")) }}
   annotations:
-    {{- toYaml $mergedAnnotations | nindent 4 }}
-    {{- if .Values.ipWhitelist }}
+    {{- with $mergedAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if and .Values.ipWhitelist (eq $controller "nginx") }}
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ join "," .Values.ipWhitelist }}"
     {{- end }}
   {{- end }}
 spec:
+  {{- $className := include "mgnl.ingressClassName" (dict "instance" .Values.magnoliaAuthor.ingress.className "ctx" $) }}
+  {{- if $className }}
+  ingressClassName: {{ $className }}
+  {{- end }}
   tls:
     - hosts:
         - {{ .Values.magnoliaAuthor.ingress.hostname }}

--- a/helm/templates/magnolia-public-assets.ing.yaml
+++ b/helm/templates/magnolia-public-assets.ing.yaml
@@ -11,12 +11,25 @@ metadata:
   name: {{ include "mgnl.public.name" . }}-assets
   labels:
     {{- include "mgnl.labels" . | nindent 4 }}
-  {{- $mergedAnnotations := include "mgnl.public.assetIngress.annotations" . | fromYaml }}
+  {{- $controller := include "mgnl.ingress.controller" . }}
+  {{- $userAnnotations := include "mgnl.public.assetIngress.annotations" . | fromYaml }}
+  {{- $builtin := dict }}
+  {{- if eq $controller "nginx" }}
+  {{- $builtin = `nginx.ingress.kubernetes.io/rewrite-target: /dam/$1
+nginx.ingress.kubernetes.io/configuration-snippet: |
+  more_set_headers "X-Robots-Tag: noindex";
+` | fromYaml }}
+  {{- end }}
+  {{- $mergedAnnotations := merge $userAnnotations $builtin }}
   {{- if $mergedAnnotations }}
   annotations:
     {{- toYaml $mergedAnnotations | nindent 4 }}
   {{- end }}
 spec:
+  {{- $className := include "mgnl.ingressClassName" (dict "instance" .Values.magnoliaPublic.assetIngress.className "ctx" $) }}
+  {{- if $className }}
+  ingressClassName: {{ $className }}
+  {{- end }}
   tls:
     - hosts:
         - {{ .Values.magnoliaPublic.assetIngress.hostname }}
@@ -25,8 +38,10 @@ spec:
     - host: {{ .Values.magnoliaPublic.assetIngress.hostname }}
       http:
         paths:
-          - path: /(.*)
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+          - path: {{ if eq $controller "traefik" }}/{{ else }}/(.*){{ end }}
+            {{- if eq $controller "traefik" }}
+            pathType: Prefix
+            {{- else if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: ImplementationSpecific
             {{- end }}
             backend:

--- a/helm/templates/magnolia-public.ing.yaml
+++ b/helm/templates/magnolia-public.ing.yaml
@@ -15,15 +15,22 @@ metadata:
       {{- toYaml $mergedLabels | nindent 4 }}
     {{- end }}
     {{- include "mgnl.labels" . | nindent 4 }}
+  {{- $controller := include "mgnl.ingress.controller" . }}
   {{- $mergedAnnotations := include "mgnl.public.ingress.annotations" . | fromYaml }}
-  {{- if $mergedAnnotations }}
+  {{- if or $mergedAnnotations (and .Values.ipWhitelist (eq $controller "nginx")) }}
   annotations:
-    {{- toYaml $mergedAnnotations | nindent 4 }}
-    {{- if .Values.ipWhitelist }}
+    {{- with $mergedAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if and .Values.ipWhitelist (eq $controller "nginx") }}
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ join "," .Values.ipWhitelist }}"
     {{- end }}
   {{- end }}
 spec:
+  {{- $className := include "mgnl.ingressClassName" (dict "instance" .Values.magnoliaPublic.ingress.className "ctx" $) }}
+  {{- if $className }}
+  ingressClassName: {{ $className }}
+  {{- end }}
   tls:
     - hosts:
         - {{ .Values.magnoliaPublic.ingress.hostname }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -169,6 +169,12 @@ magnolia:
     port: 3306
   # Shared ingress defaults (merged with instance-specific)
   ingress:
+    # Ingress controller type: nginx | traefik.
+    # Drives path syntax and which built-in controller annotations are emitted.
+    controller: nginx
+    # ingressClassName applied to every Ingress (empty = omit, use cluster default class).
+    # Can be overridden per-ingress via the instance-level `className`.
+    className: ""
     annotations: {}
     labels: {}
   # Shared asset ingress defaults (merged with instance-specific)
@@ -211,18 +217,23 @@ magnoliaPublic:
   assetIngress:
     enabled: false
     hostname: magnolia-public-assets.local
+    # Override the shared ingressClassName for this ingress (empty = use shared).
+    className: ""
     secret:
       enabled: false
       ca: ""
       cert: ""
       key: ""
-    annotations:
-      nginx.ingress.kubernetes.io/rewrite-target: /dam/$1
-      nginx.ingress.kubernetes.io/configuration-snippet: |
-        more_set_headers "X-Robots-Tag: noindex";
+    # Extra annotations. The /dam rewrite and X-Robots-Tag header are emitted
+    # automatically for controller=nginx. For controller=traefik, supply a
+    # Middleware (addPrefix /dam + customResponseHeaders) via:
+    #   traefik.ingress.kubernetes.io/router.middlewares: <ns>-<mw>@kubernetescrd
+    annotations: {}
   ingress:
     enabled: true
     hostname: magnolia-public.local
+    # Override the shared ingressClassName for this ingress (empty = use shared).
+    className: ""
     secret:
       enabled: false
       ca: ""
@@ -264,18 +275,23 @@ magnoliaAuthor:
   assetIngress:
     enabled: false
     hostname: magnolia-author-assets.local
+    # Override the shared ingressClassName for this ingress (empty = use shared).
+    className: ""
     secret:
       enabled: false
       ca: ""
       cert: ""
       key: ""
-    annotations:
-      nginx.ingress.kubernetes.io/rewrite-target: /dam/$1
-      nginx.ingress.kubernetes.io/configuration-snippet: |
-        more_set_headers "X-Robots-Tag: noindex";
+    # Extra annotations. The /dam rewrite and X-Robots-Tag header are emitted
+    # automatically for controller=nginx. For controller=traefik, supply a
+    # Middleware (addPrefix /dam + customResponseHeaders) via:
+    #   traefik.ingress.kubernetes.io/router.middlewares: <ns>-<mw>@kubernetescrd
+    annotations: {}
   ingress:
     enabled: true
     hostname: magnolia-author.local
+    # Override the shared ingressClassName for this ingress (empty = use shared).
+    className: ""
     secret:
       enabled: false
       ca: ""
@@ -288,8 +304,15 @@ magnoliaAuthor:
     authorPrefix: author
     permanent: false
     routes:
+        # path/pathType are optional per-route overrides for the ingress match.
+        # nginx: omit to use the regex match /<pathPrefix>(?:/.+)?\.html.
+        # traefik: cannot do regex paths in a plain Ingress — set an explicit
+        # path (e.g. /author) and pathType (Prefix); the sidecar's own nginx
+        # config still performs the real .html match and redirect.
       - pathPrefix: ""
         target: ""
+        path: ""
+        pathType: ""
     image:
       repository: nginx
       tag: 1.31-alpine@sha256:d565d19ef132a5834f5897f602831ad2e40a36c26c625f2f94f9b3fdf0ed292d
@@ -300,6 +323,8 @@ magnoliaAuthor:
       limits:
         memory: 32Mi
     ingress:
+      # Override the shared ingressClassName for this ingress (empty = use shared).
+      className: ""
       annotations: {}
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
Add magnolia.ingress.controller (nginx|traefik) and ingressClassName support to all ingress templates. nginx stays the default and renders unchanged.

For controller=traefik:
- emit ingressClassName on every ingress (per-instance overridable via the instance-level className)
- asset ingress uses `path: /` with pathType Prefix instead of the nginx `/(.*)` regex; the /dam rewrite-target and X-Robots-Tag snippet are emitted only for nginx (wire a Traefik Middleware via annotations)
- preview-redirect supports per-route path/pathType overrides instead of the nginx-only regex match
- whitelist-source-range and use-regex annotations are gated to nginx

Also fix whitelist-source-range being silently dropped on the author/public main ingress when no other annotations were set.